### PR TITLE
Mark each test as either unit or integration test

### DIFF
--- a/app/database/test/test_element_routing.py
+++ b/app/database/test/test_element_routing.py
@@ -43,6 +43,8 @@ from ..api.main import app
 from spacenet.test.element_factories import *
 from .utilities import with_type, make_subset, first_subset_second, filter_val_not_none
 
+pytestmark = [pytest.mark.integration, pytest.mark.element]
+
 client = TestClient(app)
 
 TEST_DB_URL = "sqlite:///./test.db"

--- a/app/database/test/test_hello_world.py
+++ b/app/database/test/test_hello_world.py
@@ -1,12 +1,15 @@
 import unittest
 import json
 import pkg_resources
+import pytest
 
 from spacenet import test
 
 from app.database.api.models import hello_world as models
 from app.database.api.schemas import hello_world as schemas
 from app.database.api.database import Base, SessionLocal, engine
+
+pytestmark = [pytest.mark.unit]
 
 
 class TestHelloWorld(unittest.TestCase):

--- a/app/database/test/test_resource.py
+++ b/app/database/test/test_resource.py
@@ -1,12 +1,16 @@
 import unittest
 import json
 import pkg_resources
+import pytest
 
 from spacenet import test
 
 from app.database.api.models import resource as models
 from app.database.api.schemas import resource as schemas
 from app.database.api.database import SessionLocal, Base, engine
+
+pytestmark = [pytest.mark.unit, pytest.mark.resource]
+
 
 class TestResource(unittest.TestCase):
     def setUp(self):

--- a/app/database/test/test_resource_routing.py
+++ b/app/database/test/test_resource_routing.py
@@ -15,6 +15,7 @@ from ..api.database import Base, get_db
 from ..api.models.resource import Resource as ResourceModel
 from ..api.main import app
 
+pytestmark = [pytest.mark.integration, pytest.mark.resource]
 
 client = TestClient(app)
 
@@ -36,7 +37,6 @@ def override_get_db():
 
 
 app.dependency_overrides[get_db] = override_get_db
-
 
 VALID_DISCRETE_ARGS = {
     "name": "foo",
@@ -69,18 +69,13 @@ OTHER_VALID_CONT_ARGS = {
     "cos": 2,
 }
 
-
 INVALID_DISCRETE_ARGS = {**VALID_DISCRETE_ARGS, "cos": 99999}
-
 
 MISTYPED_DISCRETE_ARGS = {**VALID_CONT_ARGS, "unit_mass": 10, "unit_volume": 20}
 
-
 INVALID_CONT_ARGS = {**VALID_CONT_ARGS, "cos": -10}
 
-
 MISTYPED_CONT_ARGS = {**VALID_DISCRETE_ARGS, "unit_mass": 10.2, "unit_volume": 24.1}
-
 
 KIND_TO_ARGS: Dict[ResourceType, Tuple[Dict, Dict, Dict, Dict]] = {
     ResourceType.discrete: (
@@ -96,7 +91,6 @@ KIND_TO_ARGS: Dict[ResourceType, Tuple[Dict, Dict, Dict, Dict]] = {
         MISTYPED_CONT_ARGS,
     ),
 }
-
 
 TESTED_VARIANTS: List[ResourceType] = [ResourceType.discrete, ResourceType.continuous]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+markers =
+    integration: marks integration tests
+    unit: marks unit tests
+    edge: marks tests for edges
+    element: marks tests for elements
+    node: marks tests for nodes
+    resource: marks tests for resources
+    state: marks tests for states

--- a/spacenet/test/test_edge.py
+++ b/spacenet/test/test_edge.py
@@ -1,9 +1,14 @@
 import unittest
+
+import pytest
 from pydantic import ValidationError
 from spacenet.schemas.edge import SurfaceEdge, SpaceEdge, FlightEdge
 
+pytestmark = [pytest.mark.unit, pytest.mark.edge]
+
 
 class TestEdge(unittest.TestCase):
+
     def testSurEdge(self):
         goodData = {"name": "FL-GA", "id": 1, "description": "Surface Edge from Florida to Georgia", "type": "Surface", "origin_id": 1, "destination_id": 2, "distance": 100}
         badTypeData = {"name": "FL-GA", "id": 1, "description": "Surface Edge from Florida to Georgia", "type": "orbital", "origin_id": 1, "destination_id": 2, "distance": 100}

--- a/spacenet/test/test_element.py
+++ b/spacenet/test/test_element.py
@@ -39,6 +39,7 @@ import random
 import unittest
 from typing import Tuple, Type
 
+import pytest
 from pydantic import ValidationError
 
 from spacenet.schemas.element import *
@@ -47,6 +48,7 @@ from spacenet.schemas.element import (
 )
 from .element_factories import *
 
+pytestmark = [pytest.mark.unit, pytest.mark.element]
 NUM_ATTEMPTS = 500
 SEED = "spacenet"
 

--- a/spacenet/test/test_hello_world.py
+++ b/spacenet/test/test_hello_world.py
@@ -1,23 +1,28 @@
 import unittest
 import json
 import pkg_resources
+import pytest
 
 from spacenet.schemas.hello_world import HelloWorld
 from pydantic import ValidationError
 
+pytestmark = [pytest.mark.unit]
+
+
 class TestHelloWorld(unittest.TestCase):
+
     def test_good_data(self):
-        good_data = { "message": "Hello World" }
+        good_data = {"message": "Hello World"}
         hello = HelloWorld(**good_data)
         self.assertEqual(hello.message, good_data.get("message"))
 
     def test_bad_data_missing_message(self):
-        bad_data = { "contents": "Hello World" }
+        bad_data = {"contents": "Hello World"}
         with self.assertRaises(ValidationError):
             hello = HelloWorld(**bad_data)
 
     def test_bad_data_message_type(self):
-        bad_data = { "message": ["Hello World"] }
+        bad_data = {"message": ["Hello World"]}
         with self.assertRaises(ValidationError):
             hello = HelloWorld(**bad_data)
 

--- a/spacenet/test/test_mixins.py
+++ b/spacenet/test/test_mixins.py
@@ -5,13 +5,14 @@ partitions.
 """
 import copy
 import unittest
-from uuid import UUID
 
+import pytest
 from pydantic import BaseModel, Field, conint
 from pydantic.fields import ModelField
 
 from spacenet.schemas.mixins import OptionalFields, RequiresID
 
+pytestmark = [pytest.mark.unit]
 
 class TestOptionalFields(unittest.TestCase):
     """
@@ -26,6 +27,7 @@ class TestOptionalFields(unittest.TestCase):
         b: float = Field(description="test")
         c: conint(ge=0)
 
+    
     def test_all_made_optional(self):
         class OptionalModel(self.Model, OptionalFields):
             pass
@@ -38,6 +40,7 @@ class TestOptionalFields(unittest.TestCase):
             # using repr b/c __eq__ isn't implemented for Field
             self.assertEqual(repr(exp_field), repr(actual_field))
 
+    
     def test_some_made_optional(self):
         class PartialOptionalModel(self.Model, OptionalFields, excluded_fields={"a"}):
             pass
@@ -67,6 +70,7 @@ class TestRequiresID(unittest.TestCase):
     class Model(BaseModel):
         pass
 
+    
     def test_requires_uuid(self):
         class ModelWithID(self.Model, RequiresID):
             pass

--- a/spacenet/test/test_node.py
+++ b/spacenet/test/test_node.py
@@ -1,7 +1,10 @@
 import unittest
 
+import pytest
 from pydantic import ValidationError
 from spacenet.schemas.node import SurfaceNode, OrbitalNode, LagrangeNode
+
+pytestmark = [pytest.mark.unit, pytest.mark.node]
 
 
 class TestNode(unittest.TestCase):

--- a/spacenet/test/test_resource.py
+++ b/spacenet/test/test_resource.py
@@ -1,4 +1,6 @@
 import unittest
+
+import pytest
 from pydantic import ValidationError
 from spacenet.schemas.resource import (
     DiscreteResource,
@@ -6,6 +8,8 @@ from spacenet.schemas.resource import (
     ResourceType,
     ClassOfSupply,
 )
+
+pytestmark = [pytest.mark.unit, pytest.mark.resource]
 
 
 class TestDisResource(unittest.TestCase):
@@ -101,6 +105,7 @@ class TestDisResource(unittest.TestCase):
 
 
 class TestConResource(unittest.TestCase):
+
     def test_good_data(self):
         name_ = "Fuel"
         type_ = ResourceType("continuous")


### PR DESCRIPTION
- Allows for running unit and integration tests separately more easily
- Done at present by marking each module as either containing unit or
  integration tests