### PR TITLE
Make docker push only happen on manual trigger

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,10 @@
 name: Publish Docker image
 on:
-  workflow_run:
-    workflows: [ "Build and Test" ]
-    branches: [ main ]
-    types:
-      - completed
+#  workflow_run:
+#    workflows: [ "Build and Test" ]
+#    branches: [ main ]
+#    types:
+#      - completed
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Current image would be broken for edges and fail silently: don't push