### PR TITLE
Use UUIDs for element events and avoid referring to database entries directly

### DIFF
--- a/spacenet/schemas/element_events.py
+++ b/spacenet/schemas/element_events.py
@@ -1,53 +1,66 @@
 from typing import Dict, List
+from uuid import UUID
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 
-NODE_OR_EDGE = Literal["Node", "Edge"]
-NODE_OR_EDGE_OR_CARRIER = Literal["Node", "Edge", "ElementCarrier"]
+class MakeElementsEvent(BaseModel):
+    """
+    An event which brings elements "into" a simulation
+    at a specific time and location (node, edge, or inside an element carrier).
+    """
 
-
-class MakeElementEvent(BaseModel):
-    element_id: StrictInt = Field(
-        ..., description="the id of the element being added to simulation"
+    element_id: List[UUID] = Field(
+        ..., description="the IDs of the elements being added to simulation"
     )
-    entry_point_kind: NODE_OR_EDGE_OR_CARRIER = Field(
-        description="the type of entry point the element is entering at"
-    )
-    entry_point_id: StrictInt = Field(
-        ..., description="the id of the entry point the element is being added at"
+    entry_point_id: UUID = Field(
+        ..., description="the ID of the entry point the element is being added at"
     )
 
 
 class MoveElementsEvent(BaseModel):
-    to_move: List[StrictInt] = Field(
-        ..., description="the list of IDs of elements to move"
-    )
-    origin_kind: NODE_OR_EDGE
-    origin_id: StrictInt = Field(
+    """
+    An event which moves elements at a specific time and location (node or edge)
+    to a new location (node, edge, or element carrier).
+    """
+
+    to_move: List[UUID] = Field(..., description="the list of IDs of elements to move")
+    origin_id: UUID = Field(
         ...,
-        description="the id of the original time and location "
+        description="the ID of the original time and location "
         "which the elements are being moved from",
     )
-    destination_kind: NODE_OR_EDGE_OR_CARRIER
-    destination_id: StrictInt
+    destination_id: UUID
 
 
 class RemoveElementsEvent(BaseModel):
-    to_remove: List[StrictInt] = Field(
+    """
+    An event which deletes elements from the simulation
+    at a specific time and location (node or edge).
+    """
+
+    to_remove: List[UUID] = Field(
         ..., description="the list of IDs of elements to remove"
     )
-    removal_point_kind: NODE_OR_EDGE
-    removal_point_id: StrictInt
+    removal_point_id: UUID = Field(
+        ..., description="the ID of the node or edge to remove elements from"
+    )
 
 
 State = Literal["Active", "Decommissioned", "Dormant"]
 
 
 class ReconfigureElementsEvent(BaseModel):
-    to_reconfigure: Dict[StrictInt, State] = Field(
+    """
+    An event which changes the operational state for elements
+    at a specific time and location (node or edge).
+    """
+
+    to_reconfigure: Dict[UUID, State] = Field(
         ..., description="a mapping from the IDs of elements to their desired new state"
     )
-    reconfigure_point_kind: NODE_OR_EDGE
-    reconfigure_point_id: StrictInt
+    reconfigure_point_id: UUID = Field(
+        ...,
+        description="the ID of the node or edge to reconfigure elements at",
+    )

--- a/spacenet/test/events/event_utilities.py
+++ b/spacenet/test/events/event_utilities.py
@@ -1,36 +1,31 @@
 from typing import List, Tuple, Type
+from uuid import UUID
 
 from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
-from pydantic import ValidationError, BaseModel
+from pydantic import BaseModel, ValidationError
 
 
-def is_integer(s: str) -> bool:
+def is_valid_uuid(s: str) -> bool:
     """
-    Return true if s represents an integer, and false otherwise.
+    Return true if s can be converted into a valid UUID, and false otherwise.
 
-    :param s: value to check if represents an integer
-    :return: true if s represents an integer, false otherwise
-    >>> is_integer("5")
-    True
-    >>> is_integer("five")
+    :param s: value to check if can be converted into a valid UUID
+    :return: true if s can be converted into a valid UUID, false otherwise
+    >>> is_valid_uuid("hello")
     False
-    >>> is_integer("-5")
+    >>> is_valid_uuid("123e4567-e89b-12d3-a456-426614174000")
     True
-    >>> is_integer("5.1")
-    False
     """
     try:
-        int(s)
+        UUID(hex=s)
     except ValueError:
         return False
     else:
         return True
 
 
-INVALID_INTS = st.one_of(
-    st.integers().map(lambda x: x + 0.1), st.text().filter(lambda s: not is_integer(s))
-)
+INVALID_UUIDS = st.text().filter(lambda s: not is_valid_uuid(s))
 
 
 def valid_invalid_from_allowed(

--- a/spacenet/test/events/test_make_element_event.py
+++ b/spacenet/test/events/test_make_element_event.py
@@ -2,46 +2,33 @@ import pytest
 from hypothesis import given, strategies as st
 
 from spacenet.schemas.element_events import MakeElementEvent
-from .event_utilities import (
-    INVALID_INTS,
-    valid_invalid_from_allowed,
-    xfail_from_kw,
-    success_from_kw,
-)
+from .event_utilities import INVALID_UUIDS, success_from_kw, xfail_from_kw
 
 pytestmark = [pytest.mark.unit, pytest.mark.event]
 
-ALLOWED_KINDS = ["Node", "Edge", "ElementCarrier"]
-VALID_ELE_IDS = st.integers()
-INVALID_ELE_IDS = INVALID_INTS
-VALID_KINDS, INVALID_KINDS = valid_invalid_from_allowed(ALLOWED_KINDS)
-VALID_ENTRY_IDS = st.integers()
-INVALID_ENTRY_IDS = INVALID_ELE_IDS
-
 
 VALID_MAP = {
-    "element_id": st.integers(),
-    "entry_point_kind": VALID_KINDS,
-    "entry_point_id": st.integers(),
+    "element_id": st.uuids(),
+    "entry_point_id": st.uuids(),
 }
 
 INVALID_MAP = {
-    "element_id": INVALID_INTS,
-    "entry_point_kind": INVALID_KINDS,
-    "entry_point_id": INVALID_INTS,
+    "element_id": INVALID_UUIDS,
+    "entry_point_id": INVALID_UUIDS,
 }
 
 
-def xfail_construct_make(element_id, entry_point_kind, entry_point_id):
+def xfail_construct_make(element_id, entry_point_id):
     return xfail_from_kw(
         MakeElementEvent,
         element_id=element_id,
-        entry_point_kind=entry_point_kind,
         entry_point_id=entry_point_id,
     )
 
 
-@given(kw=st.fixed_dictionaries(mapping=VALID_MAP),)
+@given(
+    kw=st.fixed_dictionaries(mapping=VALID_MAP),
+)
 def test_valid(kw):
     success_from_kw(MakeElementEvent, **kw)
 
@@ -52,15 +39,6 @@ def test_valid(kw):
     )
 )
 def test_invalid_element_id(kw):
-    xfail_construct_make(**kw)
-
-
-@given(
-    kw=st.fixed_dictionaries(
-        mapping={**VALID_MAP, "entry_point_kind": INVALID_MAP["entry_point_kind"]}
-    )
-)
-def test_invalid_entry_point_kind(kw):
     xfail_construct_make(**kw)
 
 

--- a/spacenet/test/events/test_make_element_event.py
+++ b/spacenet/test/events/test_make_element_event.py
@@ -1,26 +1,26 @@
 import pytest
 from hypothesis import given, strategies as st
 
-from spacenet.schemas.element_events import MakeElementEvent
+from spacenet.schemas.element_events import MakeElementsEvent
 from .event_utilities import INVALID_UUIDS, success_from_kw, xfail_from_kw
 
 pytestmark = [pytest.mark.unit, pytest.mark.event]
 
 
 VALID_MAP = {
-    "element_id": st.uuids(),
+    "element_id": st.lists(st.uuids()),
     "entry_point_id": st.uuids(),
 }
 
 INVALID_MAP = {
-    "element_id": INVALID_UUIDS,
+    "element_id": st.lists(INVALID_UUIDS, min_size=1),
     "entry_point_id": INVALID_UUIDS,
 }
 
 
 def xfail_construct_make(element_id, entry_point_id):
     return xfail_from_kw(
-        MakeElementEvent,
+        MakeElementsEvent,
         element_id=element_id,
         entry_point_id=entry_point_id,
     )
@@ -30,7 +30,7 @@ def xfail_construct_make(element_id, entry_point_id):
     kw=st.fixed_dictionaries(mapping=VALID_MAP),
 )
 def test_valid(kw):
-    success_from_kw(MakeElementEvent, **kw)
+    success_from_kw(MakeElementsEvent, **kw)
 
 
 @given(
@@ -38,7 +38,7 @@ def test_valid(kw):
         mapping={**VALID_MAP, "element_id": INVALID_MAP["element_id"]}
     )
 )
-def test_invalid_element_id(kw):
+def test_invalid_element_ids(kw):
     xfail_construct_make(**kw)
 
 

--- a/spacenet/test/events/test_move_element_event.py
+++ b/spacenet/test/events/test_move_element_event.py
@@ -3,45 +3,31 @@ from hypothesis import given, strategies as st
 
 from spacenet.schemas.element_events import MoveElementsEvent
 from .event_utilities import (
-    INVALID_INTS,
+    INVALID_UUIDS,
     success_from_kw,
-    valid_invalid_from_allowed,
     xfail_from_kw,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.event]
 
-ALLOWED_ORIGINS = ["Node", "Edge"]
-ALLOWED_DESTINATIONS = ["Node", "Edge", "ElementCarrier"]
-VALID_ORIGINS, INVALID_ORIGINS = valid_invalid_from_allowed(ALLOWED_ORIGINS)
-VALID_DESTS, INVALID_DESTS = valid_invalid_from_allowed(ALLOWED_DESTINATIONS)
-
 VALID_MAP = {
-    "to_move": st.lists(st.integers()),
-    "origin_id": st.integers(),
-    "destination_id": st.integers(),
-    "origin_kind": VALID_ORIGINS,
-    "destination_kind": VALID_DESTS,
+    "to_move": st.lists(st.uuids()),
+    "origin_id": st.uuids(),
+    "destination_id": st.uuids(),
 }
 
 INVALID_MAP = {
-    "to_move": st.lists(INVALID_INTS, min_size=1),
-    "origin_id": INVALID_INTS,
-    "destination_id": INVALID_INTS,
-    "origin_kind": INVALID_ORIGINS,
-    "destination_kind": INVALID_DESTS,
+    "to_move": st.lists(INVALID_UUIDS, min_size=1),
+    "origin_id": INVALID_UUIDS,
+    "destination_id": INVALID_UUIDS,
 }
 
 
-def xfail_construct_move(
-    to_move, origin_kind, origin_id, destination_kind, destination_id
-):
+def xfail_construct_move(to_move, origin_id, destination_id):
     xfail_from_kw(
         MoveElementsEvent,
         to_move=to_move,
-        origin_kind=origin_kind,
         origin_id=origin_id,
-        destination_kind=destination_kind,
         destination_id=destination_id,
     )
 
@@ -49,7 +35,8 @@ def xfail_construct_move(
 @given(kw=st.fixed_dictionaries(mapping=VALID_MAP))
 def test_valid(kw):
     success_from_kw(
-        MoveElementsEvent, **kw,
+        MoveElementsEvent,
+        **kw,
     )
 
 
@@ -62,28 +49,10 @@ def test_invalid_to_move(kw):
 
 @given(
     kw=st.fixed_dictionaries(
-        mapping={**VALID_MAP, "origin_kind": INVALID_MAP["origin_kind"]}
-    )
-)
-def test_invalid_origin_kind(kw):
-    xfail_construct_move(**kw)
-
-
-@given(
-    kw=st.fixed_dictionaries(
         mapping={**VALID_MAP, "origin_id": INVALID_MAP["origin_id"]}
     )
 )
 def test_invalid_origin_id(kw):
-    xfail_construct_move(**kw)
-
-
-@given(
-    kw=st.fixed_dictionaries(
-        mapping={**VALID_MAP, "destination_kind": INVALID_MAP["destination_kind"]}
-    )
-)
-def test_invalid_destination_kind(kw):
     xfail_construct_move(**kw)
 
 

--- a/spacenet/test/events/test_reconfigure_element_event.py
+++ b/spacenet/test/events/test_reconfigure_element_event.py
@@ -3,29 +3,24 @@ from hypothesis import given, strategies as st
 
 from spacenet.schemas.element_events import ReconfigureElementsEvent
 from .event_utilities import (
-    INVALID_INTS,
+    INVALID_UUIDS,
     success_from_kw,
-    valid_invalid_from_allowed,
     xfail_from_kw,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.event]
 
-ALLOWED_RECONFIG_POINTS = ["Node", "Edge"]
-VALID_RECONF, INVALID_RECONF = valid_invalid_from_allowed(ALLOWED_RECONFIG_POINTS)
 STATES = ("Active", "Dormant", "Decommissioned")
-VALID_TO_RECONFIGURE = st.dictionaries(
-    keys=st.integers(), values=st.sampled_from(STATES)
-)
+VALID_TO_RECONFIGURE = st.dictionaries(keys=st.uuids(), values=st.sampled_from(STATES))
 INVALID_TO_RECONFIGURE = st.one_of(
-    st.dictionaries(keys=INVALID_INTS, values=st.sampled_from(STATES), min_size=1),
+    st.dictionaries(keys=INVALID_UUIDS, values=st.sampled_from(STATES), min_size=1),
     st.dictionaries(
-        keys=st.integers(),
+        keys=st.uuids(),
         values=st.text().filter(lambda s: s not in STATES),
         min_size=1,
     ),
     st.dictionaries(
-        keys=INVALID_INTS,
+        keys=INVALID_UUIDS,
         values=st.text().filter(lambda s: s not in STATES),
         min_size=1,
     ),
@@ -33,24 +28,21 @@ INVALID_TO_RECONFIGURE = st.one_of(
 
 VALID_MAP = {
     "to_reconfigure": VALID_TO_RECONFIGURE,
-    "reconfigure_point_kind": VALID_RECONF,
-    "reconfigure_point_id": st.integers(),
+    "reconfigure_point_id": st.uuids(),
 }
 
 INVALID_MAP = {
     "to_reconfigure": INVALID_TO_RECONFIGURE,
-    "reconfigure_point_kind": INVALID_RECONF,
-    "reconfigure_point_id": INVALID_INTS,
+    "reconfigure_point_id": INVALID_UUIDS,
 }
 
 
 def xfail_construct_reconfigure(
-    to_reconfigure, reconfigure_point_kind, reconfigure_point_id
+    to_reconfigure, reconfigure_point_id
 ):
     xfail_from_kw(
         ReconfigureElementsEvent,
         to_reconfigure=to_reconfigure,
-        reconfigure_point_kind=reconfigure_point_kind,
         reconfigure_point_id=reconfigure_point_id,
     )
 
@@ -66,18 +58,6 @@ def test_valid(kw):
     )
 )
 def test_invalid_to_reconfigure(kw):
-    xfail_construct_reconfigure(**kw)
-
-
-@given(
-    kw=st.fixed_dictionaries(
-        mapping={
-            **VALID_MAP,
-            "reconfigure_point_kind": INVALID_MAP["reconfigure_point_kind"],
-        }
-    )
-)
-def test_invalid_reconfigure_point_kind(kw):
     xfail_construct_reconfigure(**kw)
 
 

--- a/spacenet/test/events/test_remove_element_event.py
+++ b/spacenet/test/events/test_remove_element_event.py
@@ -3,7 +3,7 @@ from hypothesis import given, strategies as st
 
 from spacenet.schemas.element_events import RemoveElementsEvent
 from .event_utilities import (
-    INVALID_INTS,
+    INVALID_UUIDS,
     success_from_kw,
     valid_invalid_from_allowed,
     xfail_from_kw,
@@ -15,23 +15,20 @@ ALLOWED_REMOVAL_POINTS = ["Node", "Edge"]
 VALID_REMOVALS, INVALID_REMOVALS = valid_invalid_from_allowed(ALLOWED_REMOVAL_POINTS)
 
 VALID_MAP = {
-    "to_remove": st.lists(st.integers()),
-    "removal_point_kind": VALID_REMOVALS,
-    "removal_point_id": st.integers(),
+    "to_remove": st.lists(st.uuids()),
+    "removal_point_id": st.uuids(),
 }
 
 INVALID_MAP = {
-    "to_remove": st.lists(INVALID_INTS, min_size=1),
-    "removal_point_kind": INVALID_REMOVALS,
-    "removal_point_id": INVALID_INTS,
+    "to_remove": st.lists(INVALID_UUIDS, min_size=1),
+    "removal_point_id": INVALID_UUIDS,
 }
 
 
-def xfail_construct_remove(to_remove, removal_point_kind, removal_point_id):
+def xfail_construct_remove(to_remove, removal_point_id):
     xfail_from_kw(
         RemoveElementsEvent,
         to_remove=to_remove,
-        removal_point_kind=removal_point_kind,
         removal_point_id=removal_point_id,
     )
 
@@ -47,15 +44,6 @@ def test_valid(kw):
     )
 )
 def test_invalid_to_remove(kw):
-    xfail_construct_remove(**kw)
-
-
-@given(
-    kw=st.fixed_dictionaries(
-        mapping={**VALID_MAP, "removal_point_kind": INVALID_MAP["removal_point_kind"]}
-    )
-)
-def test_invalid_removal_point_kind(kw):
     xfail_construct_remove(**kw)
 
 


### PR DESCRIPTION
This pull request changes the way element events are constructed by making them contain UUIDs referring to their constituent elements, nodes, or edges. This defers the responsibility of type-checking each respective element to a later validation layer, perhaps involving a Campaign object. It also may not be desirable to use a UUID type specifically, instead preferring an integer for easier interaction, but this depends on other implementation decisions and the UUID type can be assumed to not collide at any point if randomly generated, so it's preferable in isolation to use UUIDs.