### PR TITLE
Fix: upper-bound all floats by infinity

### DIFF
--- a/app/database/api/test/test_routing_pbt.py
+++ b/app/database/api/test/test_routing_pbt.py
@@ -43,7 +43,7 @@ def type_to_table(schema_cls):
 # Mapping from a given schema to the set of schemas in the same table as that schema,
 # including the original provided schema
 SCHEMAS_IN_SAME_TABLE = {
-    first: second
+    first: {second}
     for first in model_utils.SCHEMA_TO_MODEL
     for second in model_utils.SCHEMA_TO_MODEL
     if type_to_table(first) == type_to_table(second)
@@ -151,7 +151,7 @@ class DatabaseEditorCRUDRoutes(RuleBasedStateMachine):
         assert 404 == response.status_code
 
     @rule(
-        id_type_and_schema=inserted.flatmap(
+        id_table_and_schema=inserted.flatmap(
             lambda t: st.tuples(
                 st.just(t[0]),
                 st.just(type_to_table(t[1])),

--- a/spacenet/schemas/edge.py
+++ b/spacenet/schemas/edge.py
@@ -1,6 +1,8 @@
+from math import inf
+
 from typing_extensions import Literal
 
-from pydantic import BaseModel, Field, conint
+from pydantic import BaseModel, Field, confloat, conint
 from enum import Enum
 
 __all__ = ["Edge", "EdgeType", "FlightEdge", "SpaceEdge", "SurfaceEdge"]
@@ -45,8 +47,8 @@ class SurfaceEdge(Edge):
     type: Literal[EdgeType.Surface] = Field(
         title="Type", description="Type of edge",
     )
-    distance: float = Field(
-        ..., title="Distance", description="Distance of surface edge", ge=0
+    distance: confloat(ge=0, lt=inf) = Field(
+        ..., title="Distance", description="Distance of surface edge"
     )
 
 
@@ -58,8 +60,8 @@ class SpaceEdge(Edge):
     type: Literal[EdgeType.Space] = Field(
         title="Type", description="Type of edge",
     )
-    duration: float = Field(
-        ..., title="Duration", description="Duration of space edge", ge=0
+    duration: confloat(ge=0, lt=inf) = Field(
+        ..., title="Duration", description="Duration of space edge"
     )
 
 
@@ -72,12 +74,12 @@ class FlightEdge(Edge):
     type: Literal[EdgeType.Flight] = Field(
         ..., title="Type", description="Type of edge",
     )
-    duration: float = Field(
-        ..., title="duration", description="Duration of flight edge", ge=0
+    duration: confloat(ge=0, lt=inf) = Field(
+        ..., title="duration", description="Duration of flight edge"
     )
     max_crew: conint(strict=True, ge=0, le=SQLITE_MAX_INT) = Field(
         ..., title="Max Crew", description="Crew capacity for flight",
     )
-    max_cargo: float = Field(
-        ..., title="Max Cargo", description="Cargo capacity for flight", ge=0
+    max_cargo: confloat(ge=0, lt=inf) = Field(
+        ..., title="Max Cargo", description="Cargo capacity for flight"
     )

--- a/spacenet/schemas/element.py
+++ b/spacenet/schemas/element.py
@@ -3,9 +3,10 @@ This module defines the schemas for Elements, and exports them explicitly.
 """
 from abc import ABC
 from enum import Enum
+from math import inf
 from typing import Optional
 
-from pydantic import BaseModel, Field, conint, NonNegativeFloat
+from pydantic import BaseModel, Field, confloat, conint
 from typing_extensions import Literal
 
 from ..constants import Environment, ClassOfSupply, SQLITE_MAX_INT, SQLITE_MIN_INT
@@ -52,16 +53,15 @@ class Element(BaseModel):
     environment: Environment = Field(
         ..., title="Environment", description="the element's environment"
     )
-    accommodation_mass: float = Field(
+    accommodation_mass: confloat(ge=0, lt=inf) = Field(
         ...,
-        ge=0,
         title="Accommodation Mass",
         description="the amount of additional COS5 "
         "required to pack the element inside a"
         " carrier.",
     )
-    mass: NonNegativeFloat = Field(..., title="Mass", description="mass in kg")
-    volume: NonNegativeFloat = Field(..., title="Volume", description="volume in m^3")
+    mass: confloat(ge=0, lt=inf) = Field(..., title="Mass", description="mass in kg")
+    volume: confloat(ge=0, lt=inf) = Field(..., title="Volume", description="volume in m^3")
 
 
 class CargoCarrier(Element, ABC):
@@ -69,10 +69,10 @@ class CargoCarrier(Element, ABC):
     Abstract base class representing a carrier of some sort of cargo, elements or resources.
     """
 
-    max_cargo_mass: Optional[NonNegativeFloat] = Field(
+    max_cargo_mass: Optional[confloat(ge=0, lt=inf)] = Field(
         ..., title="Max Cargo Mass", description="cargo capacity constraint (kg)"
     )
-    max_cargo_volume: Optional[NonNegativeFloat] = Field(
+    max_cargo_volume: Optional[confloat(ge=0, lt=inf)] = Field(
         ...,
         title="Maximum Cargo Volume",
         description="cargo capacity constraint (m^3)",
@@ -110,12 +110,10 @@ class Agent(Element, ABC):
     An abstract base class representing a generic Agent element.
     """
 
-    active_time_fraction: float = Field(
+    active_time_fraction: confloat(ge=0, le=1) = Field(
         ...,
         title="Active Time Fraction",
         description="the fraction of the day that an agent is active (available)",
-        ge=0,
-        le=1,
     )
 
 
@@ -151,10 +149,10 @@ class PropulsiveVehicle(Vehicle):
     """
 
     type: Literal[ElementKind.Propulsive] = Field(description="the element's type")
-    isp: NonNegativeFloat = Field(
+    isp: confloat(ge=0, lt=inf) = Field(
         ..., title="Specific Impulse", description="specific impulse (s)"
     )
-    max_fuel: NonNegativeFloat = Field(
+    max_fuel: confloat(ge=0, lt=inf) = Field(
         ..., title="Maximum Fuel", description="maximum fuel (units)"
     )
     propellant_id: conint(
@@ -168,10 +166,10 @@ class SurfaceVehicle(Vehicle):
     """
 
     type: Literal[ElementKind.Surface] = Field(description="the element's type")
-    max_speed: NonNegativeFloat = Field(
+    max_speed: confloat(ge=0, lt=inf) = Field(
         ..., title="Maximum Speed", description="maximum speed (kph)"
     )
-    max_fuel: NonNegativeFloat = Field(
+    max_fuel: confloat(ge=0, lt=inf) = Field(
         ..., title="Maximum Fuel", description="maximum fuel (units)"
     )
     fuel_id: conint(

--- a/spacenet/schemas/node.py
+++ b/spacenet/schemas/node.py
@@ -1,6 +1,8 @@
+from math import inf
+
 from typing_extensions import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, confloat
 from enum import Enum
 
 __all__ = ["Body", "NodeType", "LagrangeNode", "OrbitalNode", "SurfaceNode"]
@@ -51,15 +53,13 @@ class SurfaceNode(Node):
     type: Literal[NodeType.Surface] = Field(
         ..., title="Type", description="Type of node (surface, orbital, or lagrange)",
     )
-    latitude: float = Field(
-        ..., title="Latitude", description="Latitude (decimal degrees)", ge=-90, le=90
+    latitude: confloat(ge=-90, le=90) = Field(
+        ..., title="Latitude", description="Latitude (decimal degrees)"
     )
-    longitude: float = Field(
+    longitude: confloat(ge=-180, le=180) = Field(
         ...,
         title="Longitude",
         description="Longitude (decimal degrees)",
-        ge=-180,
-        le=180,
     )
 
 
@@ -71,14 +71,14 @@ class OrbitalNode(Node):
     type: Literal[NodeType.Orbital] = Field(
         ..., title="Type", description="Type of node (surface, orbital, or lagrange)",
     )
-    apoapsis: float = Field(
-        ..., title="Apoapsis", description="Major radius of orbit", ge=0
+    apoapsis: confloat(ge=0, lt=inf) = Field(
+        ..., title="Apoapsis", description="Major radius of orbit"
     )
-    periapsis: float = Field(
-        ..., title="Periapsis", description="Minor radius of orbit", ge=0
+    periapsis: confloat(ge=0, lt=inf) = Field(
+        ..., title="Periapsis", description="Minor radius of orbit"
     )
-    inclination: float = Field(
-        ..., title="Inclination", description="Inclination of orbit", ge=0, le=90
+    inclination: confloat(ge=0, le=90) = Field(
+        ..., title="Inclination", description="Inclination of orbit"
     )
 
 


### PR DESCRIPTION
Infinity is not a serializable value for numbers, and so must be illegal for any floating-point values in schema.