### PR TITLE
Fix tests for cascading delete, enable SQLite foreign keys

### DIFF
--- a/app/database/api/database.py
+++ b/app/database/api/database.py
@@ -1,6 +1,8 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.engine import Engine
+from .utilities import set_sqlite_foreign_key_pragma
 
 SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db"
 
@@ -8,9 +10,12 @@ engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
 
+event.listens_for(Engine, "connect")(set_sqlite_foreign_key_pragma)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
 
 # Dependency
 def get_db():

--- a/app/database/api/models/edge.py
+++ b/app/database/api/models/edge.py
@@ -8,7 +8,7 @@ __all__ = ["EdgeType", "Edge", "FlightEdge", "SpaceEdge", "SurfaceEdge"]
 
 
 class Edge(Base):
-    __tablename__ = "Edges"
+    __tablename__ = "edge"
 
     id = Column(Integer, primary_key=True, index=True)
     type = Column(String)

--- a/app/database/api/models/element.py
+++ b/app/database/api/models/element.py
@@ -28,11 +28,6 @@ class Element(Base):
     accommodation_mass = Column(Float)
     mass = Column(Float)
     volume = Column(Float)
-    associated_states = relationship(
-        "State", back_populates="parent_element",
-        cascade="all, delete",
-        passive_deletes=True
-    )
 
     __mapper_args__ = {
         "polymorphic_on": type,

--- a/app/database/api/models/element.py
+++ b/app/database/api/models/element.py
@@ -17,7 +17,7 @@ __all__ = [
 
 
 class Element(Base):
-    __tablename__ = "Elements"
+    __tablename__ = "element"
 
     id = Column(Integer, primary_key=True, index=True)
     type = Column(String)
@@ -28,6 +28,9 @@ class Element(Base):
     accommodation_mass = Column(Float)
     mass = Column(Float)
     volume = Column(Float)
+    states = relationship(
+        "State", back_populates="element", cascade="all, delete-orphan"
+    )
 
     __mapper_args__ = {
         "polymorphic_on": type,

--- a/app/database/api/models/node.py
+++ b/app/database/api/models/node.py
@@ -12,7 +12,7 @@ __all__ = [
 
 
 class Node(Base):
-    __tablename__ = "Nodes"
+    __tablename__ = "node"
 
     id = Column(Integer, primary_key=True, index=True)
     type = Column(String)

--- a/app/database/api/models/resource.py
+++ b/app/database/api/models/resource.py
@@ -8,7 +8,7 @@ __all__ = ["Resource", "ResourceType", "ContinuousResource", "DiscreteResource"]
 
 
 class Resource(Base):
-    __tablename__ = "Resources"
+    __tablename__ = "resource"
 
     id = Column(Integer, primary_key=True, index=True)
     type = Column(String)

--- a/app/database/api/models/state.py
+++ b/app/database/api/models/state.py
@@ -3,16 +3,15 @@ from sqlalchemy.orm import relationship
 
 from app.database.api.database import Base
 
-__all__ = [
-    "State"
-]
+__all__ = ["State"]
 
 
 class State(Base):
-    __tablename__ = "State"
+    __tablename__ = "state"
 
     id = Column(Integer, primary_key=True, index=True)
-    element_id = Column(Integer, ForeignKey("Elements.id"), nullable=False)
+    element_id = Column(Integer, ForeignKey("element.id"), nullable=False)
     name = Column(String)
     state_type = Column(String)
     is_initial_state = Column(Boolean)
+    element = relationship("Element", back_populates="states")

--- a/app/database/api/models/state.py
+++ b/app/database/api/models/state.py
@@ -12,8 +12,7 @@ class State(Base):
     __tablename__ = "State"
 
     id = Column(Integer, primary_key=True, index=True)
-    element_id = Column(Integer, ForeignKey("Elements.id", ondelete="CASCADE"), nullable=False)
+    element_id = Column(Integer, ForeignKey("Elements.id"), nullable=False)
     name = Column(String)
     state_type = Column(String)
     is_initial_state = Column(Boolean)
-    parent_element = relationship("Element", back_populates="associated_states")

--- a/app/database/api/test/test_routing_pbt.py
+++ b/app/database/api/test/test_routing_pbt.py
@@ -10,7 +10,7 @@ from app.database.api import models
 from app.database.api.database import get_db
 from app.database.api.main import app
 from spacenet.constants import SQLITE_MAX_INT, SQLITE_MIN_INT
-from spacenet.schemas import Element
+from spacenet.schemas import Element, State
 from .utilities import get_test_db
 from ..models import utilities as model_utils
 from ..schemas.constants import CREATE_SCHEMAS, CREATE_TO_UPDATE
@@ -23,6 +23,7 @@ pytestmark = [
     pytest.mark.element,
     pytest.mark.node,
     pytest.mark.resource,
+    pytest.mark.state,
     pytest.mark.slow,
 ]
 
@@ -73,6 +74,8 @@ class DatabaseEditorCRUDRoutes(RuleBasedStateMachine):
     )
     def create(self, create_schema):
         type_ = type(create_schema)
+        if issubclass(type_, State):
+            assume(create_schema.element_id in self.model[models.Element])
         table = type_to_table(type_)
         prefix = PARENT_TO_PREFIX[table]
         schema_dict = create_schema.dict()

--- a/app/database/api/test/test_routing_pbt.py
+++ b/app/database/api/test/test_routing_pbt.py
@@ -220,4 +220,3 @@ class DatabaseEditorCRUDRoutes(RuleBasedStateMachine):
 
 
 TestRouting = DatabaseEditorCRUDRoutes.TestCase
-pytest.mark.xfail(TestRouting)

--- a/app/database/api/utilities.py
+++ b/app/database/api/utilities.py
@@ -1,0 +1,10 @@
+from sqlite3 import Connection as SQLite3Connection
+
+__all__ = ["set_sqlite_foreign_key_pragma"]
+
+
+def set_sqlite_foreign_key_pragma(conn, _connection_record):
+    if isinstance(conn, SQLite3Connection):
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()

--- a/app/database/test/test_database_object_properties.py
+++ b/app/database/test/test_database_object_properties.py
@@ -8,6 +8,7 @@ from hypothesis.stateful import RuleBasedStateMachine, rule, consumes, Bundle
 from spacenet.constants import SQLITE_MIN_INT, SQLITE_MAX_INT
 from app.database.api.models import utilities as model_utils
 from .utilities import TestingSessionLocal, test_engine
+from ..api import models
 from ..api.models.utilities import MODEL_TO_PARENT, SCHEMA_TO_MODEL, dictify_row
 
 pytestmark = [
@@ -16,6 +17,7 @@ pytestmark = [
     pytest.mark.element,
     pytest.mark.node,
     pytest.mark.resource,
+    pytest.mark.state,
     pytest.mark.slow,
 ]
 
@@ -35,6 +37,8 @@ class DatabaseOperations(RuleBasedStateMachine):
     )
     def create(self, entry):
         model_cls = SCHEMA_TO_MODEL[type(entry)]
+        if issubclass(model_cls, models.State):
+            assume(entry.element_id in self.model[models.Element])
         db_object = model_cls(**entry.dict())
         self.db.add(db_object)
         self.db.commit()

--- a/app/database/test/test_state.py
+++ b/app/database/test/test_state.py
@@ -89,9 +89,10 @@ class ElementStateInteraction(RuleBasedStateMachine):
         for state_id, state in self.states.items():
             if state["element_id"] == element_id:
                 query_result = self.db.query(models.State).get(state_id)
-                assert (
-                    query_result is None
-                ), f"Expected cascading delete but got {dictify_row(query_result)}"
+                assert query_result is None, (
+                    f"Expected cascading delete but row was still present: "
+                    f"{dictify_row(query_result)}"
+                )
                 states_to_delete.append(state_id)
         for state_id in states_to_delete:
             del self.states[state_id]
@@ -109,4 +110,3 @@ class ElementStateInteraction(RuleBasedStateMachine):
 
 
 TestElementStateInteraction = ElementStateInteraction.TestCase
-pytest.mark.xfail(TestElementStateInteraction)

--- a/app/database/test/test_state.py
+++ b/app/database/test/test_state.py
@@ -16,6 +16,7 @@ from spacenet.schemas import Element, State
 
 pytestmark = [
     pytest.mark.unit,
+    pytest.mark.database,
     pytest.mark.element,
     pytest.mark.state,
     pytest.mark.slow,

--- a/app/database/test/test_state.py
+++ b/app/database/test/test_state.py
@@ -86,6 +86,7 @@ class ElementStateInteraction(RuleBasedStateMachine):
         from_db = self.db.query(models.Element).get(element_id)
         assert self.elements.pop(element_id) == dictify_row(from_db)
         self.db.delete(from_db)
+        self.db.commit()
         states_to_delete = []
         for state_id, state in self.states.items():
             if state["element_id"] == element_id:
@@ -103,6 +104,7 @@ class ElementStateInteraction(RuleBasedStateMachine):
         from_db = self.db.query(models.State).get(state_id)
         assert self.states.pop(state_id) == dictify_row(from_db)
         self.db.delete(from_db)
+        self.db.commit()
 
     def teardown(self):
         for table in (models.State, models.Element):

--- a/app/database/test/utilities.py
+++ b/app/database/test/utilities.py
@@ -1,10 +1,15 @@
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
+
+from ..api.utilities import set_sqlite_foreign_key_pragma
 
 TEST_DB_URL = "sqlite:///./test.db"
 
 test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+
+event.listens_for(Engine, "connect")(set_sqlite_foreign_key_pragma)
 
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
 


### PR DESCRIPTION
The bug with cascading delete was in test case construction; enable SQLite foreign keys and change tests to respect foreign key constraint.