### PR TITLE
Change element and state models to natively delete instead of ORM delete

### DIFF
--- a/app/database/api/models/element.py
+++ b/app/database/api/models/element.py
@@ -30,7 +30,7 @@ class Element(Base):
     mass = Column(Float)
     volume = Column(Float)
     states = relationship(
-        "State", back_populates="element", cascade="all, delete-orphan"
+        "State", back_populates="element", passive_deletes=True
     )
 
     __mapper_args__ = {

--- a/app/database/api/models/state.py
+++ b/app/database/api/models/state.py
@@ -10,7 +10,7 @@ class State(Base):
     __tablename__ = "state"
 
     id = Column(Integer, primary_key=True, index=True)
-    element_id = Column(Integer, ForeignKey("element.id"), nullable=False)
+    element_id = Column(Integer, ForeignKey("element.id", ondelete="CASCADE"), nullable=False)
     name = Column(String)
     state_type = Column(String)
     is_initial_state = Column(Boolean)


### PR DESCRIPTION
- SQLAlchemy handled cascade deletion before, but now the models are set
  so SQLite handles this itself
- Should be a meaningful performance improvement